### PR TITLE
Refine TradingView-style series settings dialog

### DIFF
--- a/streamlit_lightweight_charts_pro/frontend/src/components/SeriesSettingsDialog.tsx
+++ b/streamlit_lightweight_charts_pro/frontend/src/components/SeriesSettingsDialog.tsx
@@ -1,0 +1,512 @@
+import React, {useMemo, useState, useCallback} from 'react'
+
+export type SeriesSettingsFieldSource = 'options' | 'topLevel'
+
+export interface SeriesSettingsSeries {
+  index: number
+  name?: string
+  type: string
+  options: Record<string, any>
+  topLevel: Record<string, any>
+}
+
+export interface SeriesSettingsGroup {
+  chartId: string
+  chartIndex: number
+  chartTitle?: string
+  series: SeriesSettingsSeries[]
+}
+
+interface SeriesSettingsDialogProps {
+  open: boolean
+  groups: SeriesSettingsGroup[]
+  hasChanges: boolean
+  onClose: () => void
+  onApply: () => void
+  onReset: () => void
+  onFieldChange: (
+    chartId: string,
+    seriesIndex: number,
+    key: string,
+    value: any,
+    source: SeriesSettingsFieldSource
+  ) => void
+}
+
+const LINE_STYLE_OPTIONS = [
+  {value: 0, label: 'Solid'},
+  {value: 1, label: 'Dotted'},
+  {value: 2, label: 'Dashed'},
+  {value: 3, label: 'Large dashed'},
+  {value: 4, label: 'Sparse dotted'}
+]
+
+const LINE_TYPE_OPTIONS = [
+  {value: 0, label: 'Simple'},
+  {value: 1, label: 'Step'},
+  {value: 2, label: 'Curved'}
+]
+
+const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3}){1,2}$/
+const DEFAULT_COLOR = '#2962ff'
+const INPUT_KEY_REGEX = /(length|period|factor|multiplier|offset|precision|source|input)/i
+
+const TABS = [
+  {id: 'inputs', label: 'Inputs'},
+  {id: 'style', label: 'Style'},
+  {id: 'visibility', label: 'Visibility'}
+] as const
+
+type TabId = (typeof TABS)[number]['id']
+
+const formatLabel = (key: string): string => {
+  return key
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, match => match.toUpperCase())
+    .trim()
+}
+
+const formatSeriesType = (type: string): string => {
+  return formatLabel(type || 'Series')
+}
+
+const getFieldPriority = (key: string): number => {
+  if (/color/i.test(key)) return 0
+  if (/lineStyle/i.test(key)) return 1
+  if (/lineType/i.test(key)) return 2
+  if (/lineWidth/i.test(key)) return 3
+  if (/opacity/i.test(key)) return 4
+  if (/visible/i.test(key)) return 5
+  return 6
+}
+
+export const isEditableStyleKey = (key: string, value: any): boolean => {
+  if (value === null || value === undefined) return false
+
+  if (typeof value === 'string') {
+    return /color|fill|background/i.test(key) || key === 'color'
+  }
+
+  if (typeof value === 'number') {
+    return (
+      /line(style|width|type)/i.test(key) ||
+      /opacity/i.test(key) ||
+      /radius|thickness|borderWidth/i.test(key) ||
+      INPUT_KEY_REGEX.test(key)
+    )
+  }
+
+  if (typeof value === 'boolean') {
+    return /visible|show|fill/i.test(key)
+  }
+
+  return false
+}
+
+interface EditableField {
+  key: string
+  value: any
+  source: SeriesSettingsFieldSource
+}
+
+const getEditableFields = (series: SeriesSettingsSeries): EditableField[] => {
+  const fields: EditableField[] = []
+
+  Object.entries(series.topLevel || {}).forEach(([key, value]) => {
+    if (isEditableStyleKey(key, value)) {
+      fields.push({key, value, source: 'topLevel'})
+    }
+  })
+
+  Object.entries(series.options || {}).forEach(([key, value]) => {
+    if (isEditableStyleKey(key, value)) {
+      fields.push({key, value, source: 'options'})
+    }
+  })
+
+  return fields.sort((a, b) => {
+    const priorityDiff = getFieldPriority(a.key) - getFieldPriority(b.key)
+    if (priorityDiff !== 0) return priorityDiff
+    return formatLabel(a.key).localeCompare(formatLabel(b.key))
+  })
+}
+
+const categorizeField = (field: EditableField): TabId => {
+  if (typeof field.value === 'boolean') {
+    return 'visibility'
+  }
+
+  if (typeof field.value === 'number' && INPUT_KEY_REGEX.test(field.key)) {
+    return 'inputs'
+  }
+
+  return 'style'
+}
+
+const getFieldsByTab = (fields: EditableField[]): Record<TabId, EditableField[]> => {
+  return fields.reduce(
+    (acc, field) => {
+      const tab = categorizeField(field)
+      acc[tab].push(field)
+      return acc
+    },
+    {inputs: [], style: [], visibility: []} as Record<TabId, EditableField[]>
+  )
+}
+
+const getDefaultTab = (fieldsByTab: Record<TabId, EditableField[]>): TabId => {
+  for (const tab of TABS) {
+    if (fieldsByTab[tab.id].length > 0) {
+      return tab.id
+    }
+  }
+
+  return 'style'
+}
+
+const renderColorField = (
+  chartId: string,
+  seriesIndex: number,
+  field: EditableField,
+  onFieldChange: SeriesSettingsDialogProps['onFieldChange']
+) => {
+  const label = formatLabel(field.key)
+  const value = typeof field.value === 'string' ? field.value : ''
+  const safeValue = HEX_COLOR_REGEX.test(value) ? value : DEFAULT_COLOR
+
+  return (
+    <div className="slwc-series-row" key={`${field.source}-${field.key}`}>
+      <div className="slwc-series-row-label">{label}</div>
+      <div className="slwc-color-control">
+        <label className="slwc-color-button">
+          <span
+            className="slwc-color-button__swatch"
+            style={{backgroundColor: value || DEFAULT_COLOR}}
+          />
+          <span className="slwc-color-button__arrow" />
+          <input
+            type="color"
+            value={safeValue}
+            aria-label={`${label} color`}
+            onChange={event =>
+              onFieldChange(chartId, seriesIndex, field.key, event.target.value, field.source)
+            }
+          />
+        </label>
+        <input
+          className="slwc-color-hex-input"
+          type="text"
+          value={value}
+          aria-label={`${label} value`}
+          placeholder={DEFAULT_COLOR.toUpperCase()}
+          onChange={event =>
+            onFieldChange(chartId, seriesIndex, field.key, event.target.value, field.source)
+          }
+        />
+      </div>
+    </div>
+  )
+}
+
+const renderLineStyleField = (
+  chartId: string,
+  seriesIndex: number,
+  field: EditableField,
+  onFieldChange: SeriesSettingsDialogProps['onFieldChange']
+) => {
+  const label = formatLabel(field.key)
+  const value = typeof field.value === 'number' ? field.value : 0
+
+  return (
+    <div className="slwc-series-row" key={`${field.source}-${field.key}`}>
+      <div className="slwc-series-row-label">{label}</div>
+      <select
+        className="slwc-select"
+        value={value}
+        aria-label={`${label} selection`}
+        onChange={event =>
+          onFieldChange(chartId, seriesIndex, field.key, Number(event.target.value), field.source)
+        }
+      >
+        {LINE_STYLE_OPTIONS.map(option => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+const renderLineTypeField = (
+  chartId: string,
+  seriesIndex: number,
+  field: EditableField,
+  onFieldChange: SeriesSettingsDialogProps['onFieldChange']
+) => {
+  const label = formatLabel(field.key)
+  const value = typeof field.value === 'number' ? field.value : 0
+
+  return (
+    <div className="slwc-series-row" key={`${field.source}-${field.key}`}>
+      <div className="slwc-series-row-label">{label}</div>
+      <select
+        className="slwc-select"
+        value={value}
+        aria-label={`${label} selection`}
+        onChange={event =>
+          onFieldChange(chartId, seriesIndex, field.key, Number(event.target.value), field.source)
+        }
+      >
+        {LINE_TYPE_OPTIONS.map(option => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+const renderNumberField = (
+  chartId: string,
+  seriesIndex: number,
+  field: EditableField,
+  onFieldChange: SeriesSettingsDialogProps['onFieldChange']
+) => {
+  const label = formatLabel(field.key)
+  const value = typeof field.value === 'number' ? field.value : 0
+  const isOpacityField = /opacity/i.test(field.key)
+
+  return (
+    <div className="slwc-series-row" key={`${field.source}-${field.key}`}>
+      <div className="slwc-series-row-label">{label}</div>
+      <input
+        className="slwc-input"
+        type="number"
+        value={value}
+        aria-label={`${label} value`}
+        step={isOpacityField ? 0.05 : 1}
+        min={isOpacityField ? 0 : undefined}
+        max={isOpacityField ? 1 : undefined}
+        onChange={event =>
+          onFieldChange(chartId, seriesIndex, field.key, Number(event.target.value), field.source)
+        }
+      />
+    </div>
+  )
+}
+
+const renderBooleanField = (
+  chartId: string,
+  seriesIndex: number,
+  field: EditableField,
+  onFieldChange: SeriesSettingsDialogProps['onFieldChange']
+) => {
+  const label = formatLabel(field.key)
+  const value = Boolean(field.value)
+  const inputId = `${chartId}-${seriesIndex}-${field.source}-${field.key}`
+
+  return (
+    <div className="slwc-series-row slwc-series-row--checkbox" key={`${field.source}-${field.key}`}>
+      <label className="slwc-checkbox" htmlFor={inputId}>
+        <input
+          id={inputId}
+          type="checkbox"
+          checked={value}
+          onChange={event =>
+            onFieldChange(chartId, seriesIndex, field.key, event.target.checked, field.source)
+          }
+          aria-label={`${label} toggle`}
+        />
+        <span className="slwc-checkbox-box">
+          <span className="slwc-checkbox-check" />
+        </span>
+        <span className="slwc-checkbox-label">{label}</span>
+      </label>
+    </div>
+  )
+}
+
+const renderField = (
+  chartId: string,
+  seriesIndex: number,
+  field: EditableField,
+  onFieldChange: SeriesSettingsDialogProps['onFieldChange']
+) => {
+  if (/color|fill|background/i.test(field.key) || field.key === 'color') {
+    return renderColorField(chartId, seriesIndex, field, onFieldChange)
+  }
+
+  if (/lineStyle/i.test(field.key)) {
+    return renderLineStyleField(chartId, seriesIndex, field, onFieldChange)
+  }
+
+  if (/lineType/i.test(field.key)) {
+    return renderLineTypeField(chartId, seriesIndex, field, onFieldChange)
+  }
+
+  if (typeof field.value === 'number') {
+    return renderNumberField(chartId, seriesIndex, field, onFieldChange)
+  }
+
+  if (typeof field.value === 'boolean') {
+    return renderBooleanField(chartId, seriesIndex, field, onFieldChange)
+  }
+
+  return null
+}
+
+const SeriesSettingsDialog: React.FC<SeriesSettingsDialogProps> = ({
+  open,
+  groups,
+  hasChanges,
+  onClose,
+  onApply,
+  onReset,
+  onFieldChange
+}) => {
+  const hasEditableSeries = useMemo(
+    () =>
+      groups.some(group =>
+        group.series.some(series => getEditableFields(series).length > 0)
+      ),
+    [groups]
+  )
+
+  const [activeTabs, setActiveTabs] = useState<Record<string, TabId>>({})
+
+  const handleTabSelect = useCallback((seriesKey: string, tab: TabId) => {
+    setActiveTabs(prev => {
+      if (prev[seriesKey] === tab) {
+        return prev
+      }
+
+      return {...prev, [seriesKey]: tab}
+    })
+  }, [])
+
+  const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose()
+    }
+  }
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div className="slwc-series-settings-overlay" role="presentation" onClick={handleOverlayClick}>
+      <div
+        className="slwc-series-settings-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Series settings dialog"
+        onClick={event => event.stopPropagation()}
+      >
+        <div className="slwc-series-settings-header">
+          <div>
+            <h2>Series settings</h2>
+            <p>Fine-tune colours, lines, and visibility to match your TradingView layouts.</p>
+          </div>
+          <button className="slwc-series-settings-close" onClick={onClose} type="button" aria-label="Close settings">
+            ×
+          </button>
+        </div>
+        <div className="slwc-series-settings-content">
+          {groups.map(group => (
+            <div className="slwc-series-group" key={group.chartId}>
+              <div className="slwc-series-group__header">
+                <span className="slwc-series-group__title">{group.chartTitle || `Chart ${group.chartIndex + 1}`}</span>
+                <span className="slwc-series-group__subtitle">{`${group.series.length} series`}</span>
+              </div>
+              <div className="slwc-series-group__body">
+                {group.series.map(series => {
+                  const editableFields = getEditableFields(series)
+                  const fieldsByTab = getFieldsByTab(editableFields)
+                  const seriesKey = `${group.chartId}-${series.index}`
+                  const storedTab = activeTabs[seriesKey]
+                  const defaultTab = getDefaultTab(fieldsByTab)
+                  const activeTab = storedTab && fieldsByTab[storedTab].length > 0 ? storedTab : defaultTab
+                  const fieldsForTab = fieldsByTab[activeTab]
+
+                  return (
+                    <div className="slwc-series-card" key={`${group.chartId}-${series.index}`}>
+                      <div className="slwc-series-card__header">
+                        <div>
+                          <h3>{series.name || `Series ${series.index + 1}`}</h3>
+                          <span>{formatSeriesType(series.type)}</span>
+                        </div>
+                        <span className="slwc-series-card__chart-ref">
+                          {group.chartTitle || `Chart #${group.chartIndex + 1}`}
+                        </span>
+                      </div>
+                      <div className="slwc-series-tabs" role="tablist">
+                        {TABS.map(tab => {
+                          const tabFields = fieldsByTab[tab.id]
+                          const isDisabled = tabFields.length === 0
+                          const isActive = activeTab === tab.id
+                          const tabClassNames = [
+                            'slwc-series-tab',
+                            isActive ? 'slwc-series-tab--active' : '',
+                            isDisabled ? 'slwc-series-tab--disabled' : ''
+                          ]
+                            .filter(Boolean)
+                            .join(' ')
+
+                          return (
+                            <button
+                              key={tab.id}
+                              type="button"
+                              role="tab"
+                              aria-selected={isActive}
+                              className={tabClassNames}
+                              disabled={isDisabled}
+                              onClick={() => handleTabSelect(seriesKey, tab.id)}
+                            >
+                              {tab.label}
+                            </button>
+                          )
+                        })}
+                      </div>
+                      {fieldsForTab.length === 0 ? (
+                        <div className="slwc-series-empty">No settings available for this tab.</div>
+                      ) : (
+                        <div className="slwc-series-field-list">
+                          {fieldsForTab.map(field =>
+                            renderField(group.chartId, series.index, field, onFieldChange)
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          ))}
+          {!hasEditableSeries && (
+            <div className="slwc-series-empty slwc-series-empty--global">
+              No editable series options were detected in the current configuration.
+            </div>
+          )}
+        </div>
+        <div className="slwc-series-settings-footer">
+          <button className="slwc-btn slwc-btn-tertiary" type="button" onClick={onReset} disabled={!hasChanges}>
+            Defaults
+          </button>
+          <div className="slwc-series-settings-actions">
+            <button className="slwc-btn slwc-btn-secondary" type="button" onClick={onClose}>
+              Cancel
+            </button>
+            <button className="slwc-btn slwc-btn-primary" type="button" onClick={onApply} disabled={!hasChanges}>
+              Ok
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default SeriesSettingsDialog

--- a/streamlit_lightweight_charts_pro/frontend/src/styles/seriesSettingsDialog.css
+++ b/streamlit_lightweight_charts_pro/frontend/src/styles/seriesSettingsDialog.css
@@ -1,0 +1,488 @@
+.slwc-chart-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+.slwc-settings-trigger {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  gap: 8px;
+  z-index: 20;
+}
+
+.slwc-settings-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: rgba(255, 255, 255, 0.9);
+  color: #1f2933;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.16);
+  transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  backdrop-filter: blur(6px);
+}
+
+.slwc-settings-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.22);
+  border-color: rgba(15, 23, 42, 0.2);
+}
+
+.slwc-settings-button:active {
+  transform: translateY(0);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.16);
+}
+
+.slwc-settings-button-icon {
+  width: 16px;
+  height: 16px;
+  color: #1f6feb;
+}
+
+.slwc-settings-button-icon path {
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.slwc-series-settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  padding: 32px 24px;
+}
+
+.slwc-series-settings-modal {
+  width: min(720px, 95vw);
+  max-height: min(700px, 92vh);
+  background: #ffffff;
+  color: #0f172a;
+  border-radius: 18px;
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.24);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.slwc-series-settings-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 24px 28px 20px;
+  border-bottom: 1px solid #eceff5;
+}
+
+.slwc-series-settings-header h2 {
+  margin: 0 0 6px;
+  font-size: 22px;
+  letter-spacing: 0.01em;
+}
+
+.slwc-series-settings-header p {
+  margin: 0;
+  color: #6b7280;
+  font-size: 13px;
+}
+
+.slwc-series-settings-close {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.05);
+  color: #111827;
+  font-size: 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.slwc-series-settings-close:hover {
+  background: rgba(15, 23, 42, 0.1);
+  border-color: rgba(15, 23, 42, 0.12);
+}
+
+.slwc-series-settings-content {
+  padding: 24px 28px 0;
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.slwc-series-settings-content::-webkit-scrollbar {
+  width: 8px;
+}
+
+.slwc-series-settings-content::-webkit-scrollbar-thumb {
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.15);
+}
+
+.slwc-series-group {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.slwc-series-group__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 12px;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.slwc-series-group__title {
+  color: #334155;
+}
+
+.slwc-series-group__body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.slwc-series-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 20px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(248, 250, 252, 0.98));
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+}
+
+.slwc-series-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 16px;
+}
+
+.slwc-series-card__header h3 {
+  margin: 0 0 4px;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.slwc-series-card__header span {
+  font-size: 13px;
+  color: #64748b;
+}
+
+.slwc-series-card__chart-ref {
+  font-size: 12px;
+  font-weight: 500;
+  color: #94a3b8;
+}
+
+.slwc-series-tabs {
+  display: flex;
+  gap: 6px;
+  border-bottom: 1px solid #e7ebf3;
+  margin: 0 -20px 18px;
+  padding: 0 20px;
+}
+
+.slwc-series-tab {
+  position: relative;
+  border: none;
+  background: none;
+  padding: 12px 6px;
+  margin-right: 16px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #94a3b8;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.slwc-series-tab--active {
+  color: #111827;
+}
+
+.slwc-series-tab--active::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: #1f6feb;
+  border-radius: 2px;
+}
+
+.slwc-series-tab--disabled {
+  color: rgba(148, 163, 184, 0.5);
+  cursor: default;
+}
+
+.slwc-series-field-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.slwc-series-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  min-height: 40px;
+}
+
+.slwc-series-row-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.slwc-color-control {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.slwc-color-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid #d8dee9;
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.slwc-color-button__swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.slwc-color-button__arrow {
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid #6b7280;
+}
+
+.slwc-color-button input[type='color'] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.slwc-color-hex-input {
+  width: 92px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid #d8dee9;
+  background: #ffffff;
+  font-family: 'SFMono-Regular', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 12px;
+  color: #111827;
+  text-transform: uppercase;
+}
+
+.slwc-color-hex-input:focus {
+  outline: none;
+  border-color: #1f6feb;
+  box-shadow: 0 0 0 3px rgba(31, 111, 235, 0.2);
+}
+
+.slwc-select,
+.slwc-input {
+  min-width: 120px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid #d8dee9;
+  background: #ffffff;
+  font-size: 13px;
+  color: #111827;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.slwc-select:focus,
+.slwc-input:focus {
+  outline: none;
+  border-color: #1f6feb;
+  box-shadow: 0 0 0 3px rgba(31, 111, 235, 0.2);
+}
+
+.slwc-select {
+  appearance: none;
+  padding-right: 32px;
+  background-image: linear-gradient(45deg, transparent 50%, #6b7280 50%),
+    linear-gradient(135deg, #6b7280 50%, transparent 50%);
+  background-position: calc(100% - 18px) calc(50% - 3px), calc(100% - 12px) calc(50% - 3px);
+  background-size: 6px 6px;
+  background-repeat: no-repeat;
+}
+
+.slwc-series-row--checkbox {
+  justify-content: flex-start;
+}
+
+.slwc-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  font-size: 13px;
+  color: #1f2937;
+  font-weight: 500;
+}
+
+.slwc-checkbox input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slwc-checkbox-box {
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.slwc-checkbox-check {
+  display: block;
+  width: 10px;
+  height: 6px;
+  border-left: 2px solid transparent;
+  border-bottom: 2px solid transparent;
+  transform: rotate(-45deg);
+  margin-top: -1px;
+  transition: border-color 0.2s ease;
+}
+
+.slwc-checkbox input:checked + .slwc-checkbox-box {
+  background: #1f6feb;
+  border-color: #1f6feb;
+}
+
+.slwc-checkbox input:checked + .slwc-checkbox-box .slwc-checkbox-check {
+  border-color: #ffffff;
+}
+
+.slwc-series-empty {
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px dashed #d0d8e5;
+  background: rgba(148, 163, 184, 0.08);
+  color: #64748b;
+  font-size: 13px;
+  text-align: center;
+}
+
+.slwc-series-empty--global {
+  margin-top: 12px;
+}
+
+.slwc-series-settings-footer {
+  padding: 18px 28px;
+  border-top: 1px solid #eceff5;
+  background: #f8fafc;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.slwc-series-settings-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.slwc-btn {
+  border-radius: 10px;
+  padding: 9px 20px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  border: 1px solid transparent;
+}
+
+.slwc-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.slwc-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.slwc-btn-primary {
+  background: #1f6feb;
+  color: #ffffff;
+  border-color: #1f6feb;
+  box-shadow: 0 12px 30px rgba(31, 111, 235, 0.3);
+}
+
+.slwc-btn-primary:hover:not(:disabled) {
+  box-shadow: 0 18px 34px rgba(31, 111, 235, 0.34);
+}
+
+.slwc-btn-secondary {
+  background: #ffffff;
+  color: #111827;
+  border-color: #d0d7e2;
+}
+
+.slwc-btn-tertiary {
+  background: transparent;
+  color: #6b7280;
+  border-color: transparent;
+}
+
+@media (max-width: 720px) {
+  .slwc-series-settings-modal {
+    width: 100%;
+    max-height: 100%;
+    border-radius: 0;
+  }
+
+  .slwc-series-settings-content {
+    padding: 20px;
+  }
+
+  .slwc-series-card {
+    padding: 16px;
+  }
+
+  .slwc-series-tabs {
+    margin: 0 -16px 16px;
+    padding: 0 16px;
+  }
+}


### PR DESCRIPTION
## Summary
- restyle the series settings dialog to mirror TradingView with tabbed sections, polished controls, and contextual grouping
- bucket editable fields into inputs/style/visibility tabs and update per-series headers for a cleaner presentation
- refresh the settings trigger button with an inline icon and refined styling consistent with the new dialog

## Testing
- npm run type-check *(fails: existing Jest mocks and tests violate TypeScript interfaces)*
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68ca404edf74832c87985f7b8d3d0f8e